### PR TITLE
refactor(default/grub): Replacing the theme name in the default/grub …

### DIFF
--- a/grub/install_script_grub.sh
+++ b/grub/install_script_grub.sh
@@ -12,8 +12,10 @@ printf "${CYAN}Copying the theme in the right folder \n"
 cp -r ./themes /boot/grub
 printf "${CYAN}If there are no error the themes was copied succefully :D \n"
 
-printf "${CYAN}Copying the grub file \n"
-cp ./default/grub /etc/default
+printf "${CYAN}Changing theme to "virtuaverser" \n"
+printf "${CYAN}You can see other settings in file ./default/grub \n"
+
+awk -i inplace '/GRUB_THEME=/ {gsub(/"[^"]+"/, "\"/boot/grub/themes/virtuaverse/theme.txt\"")} 1' /etc/default/grub
 printf "${CYAN}If there are no error grub file copied succefully \n"
 
 printf "${CYAN}Executing grub update ${NC}\n"


### PR DESCRIPTION
…file instead of copying the entire default/grub file

Replacing the entire file may corrupt the user's configuration. Instead, it is suggested to replace only the theme name. The user can do everything else at his own discretion.